### PR TITLE
fix: try upgrading pip

### DIFF
--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -166,6 +166,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET="12.0" MACOS_DEPLOYMENT_TARGET="12.0" SYSTEM_VERSION_COMPAT=0
           CIBW_TEST_COMMAND: >
             cd ${{ env.cd_option }} {project} &&
+            python3 -m pip install --upgrade pip &&
             poetry install --with devel --sync --no-root &&
             poetry run tox --skip-pkg-install -e py${{ matrix.python-version }}-${{ matrix.tox_os }}
 


### PR DESCRIPTION
windows with python3.8 and 3.9 fails 


```
    ChefBuildError
  
    Backend 'setuptools.build_meta:__legacy__' is not available.
  
    at ~\AppData\Local\Temp\cibw-run-fwneq3zj\cp38-win_amd64\venv-test\lib\site-packages\poetry\installation\chef.py:152 in _prepare
        148│ 
        149│                 error = ChefBuildError("\n\n".join(message_parts))
        150│ 
        151│             if error is not None:
      → 152│                 raise error from None
        153│ 
        154│             return path
        155│ 
        156│     def _prepare_sdist(self, archive: Path, destination: Path | None = None) -> Path:
  
  Note: This error originates from the build backend, and is likely not a problem with poetry but with bs4 (0.0.1) not supporting PEP 517 builds. You can verify this by running 'pip wheel --use-pep517 "bs4 (==0.0.1)"'.
```